### PR TITLE
Fix action name & make example useful out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ about the nixbuild.net service.
      minimal:
        runs-on: ubuntu-latest
        steps:
+         - uses: actions/checkout@v2
          - uses: nixbuild/nix-quick-install-action@v2
-         - uses: nixbuild/nixbuild@v1
+         - uses: nixbuild/nixbuild-action@v1
            with:
              nixbuild_ssh_key: ${{ secrets.nixbuild_ssh_key }}
          - run: nix-build


### PR DESCRIPTION
Previously the example did use the wrong name for the nixbuild-action (the `action` part was missing) and the CI run wouldn't be done within a checkout of the source code (the `checkout` action was missing).