### PR TITLE
Quote values of environment variables for SetEnv

### DIFF
--- a/nixbuild-action.sh
+++ b/nixbuild-action.sh
@@ -47,8 +47,9 @@ for setting in \
   never-substitute
 do
   val="$(printenv INPUTS_JSON | jq -r ".\"$setting\"")"
+  val="${val/\'/\\\'}"
   if [ -n "$val" ]; then
-    nixbuildnet_env="$nixbuildnet_env NIXBUILDNET_$(echo "$setting" | tr a-z- A-Z_)=$val"
+    nixbuildnet_env="$nixbuildnet_env NIXBUILDNET_$(echo "$setting" | tr a-z- A-Z_)='$val'"
   fi
 done
 
@@ -63,7 +64,9 @@ for tag in \
   GITHUB_REPOSITORY \
   GITHUB_SHA
 do
-  nixbuildnet_env="$nixbuildnet_env NIXBUILDNET_TAG_$tag=$(printenv $tag)"
+  val="$(printenv $tag)"
+  val="${val/\'/\\\'}"
+  nixbuildnet_env="$nixbuildnet_env NIXBUILDNET_TAG_$tag='$val'"
 done
 
 echo "  SetEnv$nixbuildnet_env" >> "$SSH_CONFIG_FILE"


### PR DESCRIPTION
If an environment variable contains spaces it can cause the action to fail with:

    /etc/ssh/ssh_config line 61: Invalid SetEnv.

The SSH configuration file parser [understands quotes and embedded escaped quotes][1] so we’ll deal with embedded quotes as well to allow using an apostrophe in a workflow name, for example.

An [example of a build with this error](https://github.com/liff/waveforms-flake/runs/3965516802?check_suite_focus=true).

[1]: https://github.com/openssh/openssh-portable/blob/bf944e3794eff5413f2df1ef37cddf96918c6bde/misc.c#L1951-L2023